### PR TITLE
Fix tar_nlmixr_multimodel() cmt(0) failure on shared piped models (#37)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # nlmixr2targets 0.1.0.9000
 
+## Bug fixes
+
+* `tar_nlmixr_multimodel()` no longer fails when a model function that
+  declares compartment initial conditions with `cmt(0) <- value` is both
+  fit directly and piped through `ini()`/`model()` in the same call (e.g.
+  `"myfit" = mod` alongside `"myfit pipe" = mod |> ini(a <- 2)`). Sharing the
+  model function between entries previously left the piped entry's command
+  referencing the internal `cmt(initial)` form, which nlmixr2 rejects (#37).
+
 ## New features
 
 * `tar_nlmixr()` and `tar_nlmixr_multimodel()` gain an `error` argument. With

--- a/R/simplify.R
+++ b/R/simplify.R
@@ -262,6 +262,52 @@ nlmixr_object_protect_zero_initial_helper <- function(expr, in_model, state) {
   expr
 }
 
+#' Does a function body contain `name(initial) <- val` inside a
+#' `model({...})` block?
+#'
+#' A model function shared across several entries of a single
+#' `tar_nlmixr_multimodel()` call is mutated in place the first time
+#' `tar_nlmixr_protect_zero_initial()` rewrites its `cmt(0)` lines to
+#' `cmt(initial)`. When a later entry (e.g. a `|>` pipe) references the
+#' same function, that call performs zero rewrites, so `total_n` no
+#' longer signals that the referenced body carries the nlmixr2-invalid
+#' `initial` form. This detector supplies that signal directly so the
+#' pipe is still wrapped for runtime restoration (issue #37).
+#'
+#' Scoped to inside `model({...})` blocks, mirroring
+#' `nlmixr_object_protect_zero_initial_helper()`.
+#'
+#' @param expr A language object (typically a function body).
+#' @returns `TRUE` if any `name(initial) <- val` occurs inside a
+#'   `model({...})` block, otherwise `FALSE`.
+#' @noRd
+nlmixr_object_body_has_model_initial <- function(expr) {
+  nlmixr_object_body_has_model_initial_helper(expr, in_model = FALSE)
+}
+
+nlmixr_object_body_has_model_initial_helper <- function(expr, in_model) {
+  if (in_model && rxode2::.matchesLangTemplate(expr, str2lang(".name(initial) <- ."))) {
+    return(TRUE)
+  }
+  if (is.call(expr)) {
+    enters_model <-
+      !in_model &&
+      length(expr) >= 1L &&
+      identical(expr[[1L]], as.name("model"))
+    for (idx in seq_along(expr)) {
+      child <- expr[[idx]]
+      # Skip NULL children (mirrors the protect helper): indexing a
+      # NULL call slot would error.
+      if (is.null(child)) next
+      child_in_model <- in_model || (enters_model && idx > 1L)
+      if (nlmixr_object_body_has_model_initial_helper(child, in_model = child_in_model)) {
+        return(TRUE)
+      }
+    }
+  }
+  FALSE
+}
+
 #' Runtime helper: undo the `cmt(0) -> cmt(initial)` rewrite before
 #' evaluating the captured `object` expression.
 #'

--- a/R/tar_nlmixr.R
+++ b/R/tar_nlmixr.R
@@ -237,38 +237,22 @@ assign_origData <- function(fit, data) {
 #'   restores the user's natural syntax at target execution time.
 #' @noRd
 tar_nlmixr_protect_zero_initial <- function(object, env) {
-  total_n <- 0L
-
-  # Pass 1: every symbol in the captured expression that points to a
-  # user-defined function in env gets its body rewritten in place.
-  # `assign(..., inherits = TRUE)` walks env upward and modifies the
-  # binding in the frame where it was originally found, so the
-  # rewrite reaches globalenv() -- which is what targets walks.
-  # Package functions are skipped: we never want to mutate, say,
-  # `rxode2::ini` or `base::model`. We also do not need to walk their
-  # bodies for cmt(0) patterns since codetools accepts them as-is
-  # (they have no DSL constructs).
-  for (sym in .collect_top_symbols(object)) {
-    if (exists(sym, envir = env, inherits = TRUE)) {
-      fn <- get(sym, envir = env, inherits = TRUE)
-      fn_env <- if (is.function(fn)) environment(fn) else NULL
-      if (is.function(fn) && !is.null(base::body(fn)) && !is.null(fn_env) && !isNamespace(fn_env)) {
-        res <- nlmixr_object_protect_zero_initial(base::body(fn))
-        if (res$n_rewrites > 0L) {
-          base::body(fn) <- res$expr
-          assign(sym, fn, envir = env, inherits = TRUE)
-          total_n <- total_n + res$n_rewrites
-        }
-      }
-    }
-  }
+  # Pass 1: rewrite every user-defined function referenced by `object` in
+  # env from cmt(0) to cmt(initial), reporting how many rewrites happened
+  # and whether any referenced body already carries cmt(initial).
+  pass1 <- tar_nlmixr_protect_zero_initial_env(object, env)
 
   # Pass 2: rewrite the captured expression itself.
   res2 <- nlmixr_object_protect_zero_initial(object)
   object <- res2$expr
-  total_n <- total_n + res2$n_rewrites
+  total_n <- pass1$total_n + res2$n_rewrites
 
-  if (total_n == 0L) {
+  # Wrap when this call rewrote something, or when a non-symbol (pipe)
+  # expression references a function already carrying cmt(initial). A bare
+  # symbol never needs the referenced-only wrap: nlmixr_object_simplify()
+  # converts cmt(initial) back to cmt(0) on the function body itself, so
+  # only expressions evaluated *before* simplification (pipes) are at risk.
+  if (total_n == 0L && !(pass1$referenced_initial && is.call(object))) {
     return(object)
   }
 
@@ -277,4 +261,48 @@ tar_nlmixr_protect_zero_initial <- function(object, env) {
     nlmixr2targets::nlmixr_object_zero_initial_eval(quote(.(x))),
     list(x = object)
   )
+}
+
+#' Pass 1 of `tar_nlmixr_protect_zero_initial()`: rewrite referenced
+#' functions' bodies in env and report the wrapping signals.
+#'
+#' Every symbol in the captured expression that points to a user-defined
+#' function in env gets its body rewritten in place from `cmt(0)` to
+#' `cmt(initial)`. `assign(..., inherits = TRUE)` walks env upward and
+#' modifies the binding in the frame where it was originally found, so the
+#' rewrite reaches `globalenv()` -- which is what `targets` walks. Package
+#' functions are skipped: we never want to mutate, say, `rxode2::ini` or
+#' `base::model`, and codetools accepts their (DSL-free) bodies as-is.
+#'
+#' @param object The captured `object` expression.
+#' @param env The user's environment.
+#' @returns A list with `total_n` (count of `cmt(0)` rewrites performed)
+#'   and `referenced_initial` (`TRUE` if any referenced function body
+#'   already carries `cmt(initial)` inside a `model({...})` block even
+#'   though this call rewrote nothing -- e.g. a sibling multimodel entry
+#'   already mutated the shared function, or the user hand-wrote the
+#'   `cmt(initial)` workaround; issue #37).
+#' @noRd
+tar_nlmixr_protect_zero_initial_env <- function(object, env) {
+  total_n <- 0L
+  referenced_initial <- FALSE
+  for (sym in .collect_top_symbols(object)) {
+    if (!exists(sym, envir = env, inherits = TRUE)) next
+    fn <- get(sym, envir = env, inherits = TRUE)
+    fn_env <- if (is.function(fn)) environment(fn) else NULL
+    if (!is.function(fn) || is.null(base::body(fn)) || is.null(fn_env) || isNamespace(fn_env)) next
+    res <- nlmixr_object_protect_zero_initial(base::body(fn))
+    if (res$n_rewrites > 0L) {
+      base::body(fn) <- res$expr
+      assign(sym, fn, envir = env, inherits = TRUE)
+      total_n <- total_n + res$n_rewrites
+    }
+    # Detect an already-rewritten (or hand-written) cmt(initial) body,
+    # which res$n_rewrites cannot report because there was no cmt(0)
+    # left to rewrite.
+    if (nlmixr_object_body_has_model_initial(base::body(fn))) {
+      referenced_initial <- TRUE
+    }
+  }
+  list(total_n = total_n, referenced_initial = referenced_initial)
 }

--- a/tests/testthat/test-simplify.R
+++ b/tests/testthat/test-simplify.R
@@ -243,6 +243,33 @@ test_that("nlmixr_object_protect_zero_initial is a no-op for non-call values", {
   }
 })
 
+test_that("nlmixr_object_body_has_model_initial detects cmt(initial) inside model({})", {
+  body_with_initial <- quote({
+    ini({ a <- 1 })
+    model({
+      d/dt(central) <- -a*central
+      central(initial) <- 3
+    })
+  })
+  expect_true(nlmixr_object_body_has_model_initial(body_with_initial))
+})
+
+test_that("nlmixr_object_body_has_model_initial is FALSE without cmt(initial)", {
+  body_plain <- quote({
+    ini({ a <- 1 })
+    model({
+      d/dt(central) <- -a*central
+      central(0) <- 3
+    })
+  })
+  expect_false(nlmixr_object_body_has_model_initial(body_plain))
+  # cmt(initial) outside a model({}) block is not matched (scoped detection).
+  expect_false(nlmixr_object_body_has_model_initial(quote(central(initial) <- 3)))
+  # Non-call leaves are handled without error.
+  expect_false(nlmixr_object_body_has_model_initial(42))
+  expect_false(nlmixr_object_body_has_model_initial(as.name("central")))
+})
+
 test_that("nlmixr_object_zero_initial_eval restores cmt(0) at runtime", {
   envir <- new.env(parent = baseenv())
   # Fake nlmixr2 model() function: captures its second arg unevaluated

--- a/tests/testthat/test-tar_nlmixr_multimodel.R
+++ b/tests/testthat/test-tar_nlmixr_multimodel.R
@@ -170,6 +170,133 @@ targets::tar_test("tar_nlmixr_multimodel works with initial condition setting `c
   expect_type(targets::tar_outdated(callr_function = NULL), "character")
 })
 
+# Issue #37: a model function carrying cmt(0) initial conditions is shared
+# between a plain entry and a piped entry (`mod |> ini(...)`). Processing the
+# plain entry mutates `mod` in env from cmt(0) to cmt(initial); the piped
+# entry then rewrites nothing, so before the fix its command was left
+# unwrapped and evaluating the pipe hit the nlmixr2-invalid `cmt(initial)`
+# form. Both entries' object-simplification commands must therefore be wrapped
+# in nlmixr_object_zero_initial_eval() so cmt(0) is restored at runtime.
+test_that("tar_nlmixr_multimodel wraps piped entries that reference a shared cmt(0) model (#37)", {
+  mod <- function() {
+    ini({
+      a <- 1
+      addSd <- 0.1
+    })
+    model({
+      b <- a
+      d/dt(central) <- -b*central
+      central(0) <- 3
+      cp <- central
+      cp ~ add(addSd)
+    })
+  }
+
+  target_list <-
+    tar_nlmixr_multimodel(
+      name = fit_pipe, data = nlmixr2data::pheno_sd, est = "saem",
+      "myfit" = mod,
+      "myfit pipe" = mod |> rxode2::ini(a <- 2)
+    )
+  # Both object-simplification commands must defer evaluation through
+  # nlmixr_object_zero_initial_eval() (order of the two model entries is
+  # irrelevant: whichever is processed second is the one previously left
+  # unwrapped).
+  is_wrapped <- function(single_target) {
+    obj_arg <- single_target$object_simple$command$expr[[1]][["object"]]
+    rxode2::.matchesLangTemplate(
+      obj_arg,
+      str2lang("nlmixr2targets::nlmixr_object_zero_initial_eval(.)")
+    )
+  }
+  expect_true(is_wrapped(target_list[[1]]))
+  expect_true(is_wrapped(target_list[[2]]))
+})
+
+# Issue #37 x #19: a self-reference pipe (`fit_pipe[["myfit"]] |> ini(...)`)
+# whose base model carries cmt(0) must NOT be wrapped in
+# nlmixr_object_zero_initial_eval(). The self-reference resolves to the base
+# model's `_fit_simple` *target* (a fitted object with cmt(0) already
+# compiled in, so there is no cmt(initial) DSL to restore), and wrapping
+# would bury that target name inside quote(), hiding it from targets'
+# dependency graph. The base model itself (bare cmt(0) function) is still
+# wrapped. This pins the boundary that separates "pipe over a source
+# function" (wrap) from "pipe over a target result" (do not wrap).
+test_that("tar_nlmixr_multimodel does not wrap a self-reference pipe over a cmt(0) model (#37/#19)", {
+  mod <- function() {
+    ini({
+      a <- 1
+      addSd <- 0.1
+    })
+    model({
+      b <- a
+      d/dt(central) <- -b*central
+      central(0) <- 3
+      cp <- central
+      cp ~ add(addSd)
+    })
+  }
+
+  target_list <-
+    tar_nlmixr_multimodel(
+      name = fit_pipe, data = nlmixr2data::pheno_sd, est = "saem",
+      "myfit" = mod,
+      "myfit pipe" = fit_pipe[["myfit"]] |> rxode2::ini(a <- 2)
+    )
+  is_wrapped <- function(single_target) {
+    obj_arg <- single_target$object_simple$command$expr[[1]][["object"]]
+    rxode2::.matchesLangTemplate(
+      obj_arg,
+      str2lang("nlmixr2targets::nlmixr_object_zero_initial_eval(.)")
+    )
+  }
+  # Base model is wrapped (bare cmt(0) function).
+  expect_true(is_wrapped(target_list[[1]]))
+  # Self-reference pipe is NOT wrapped, and its base fit_simple target stays
+  # a visible dependency.
+  expect_false(is_wrapped(target_list[[2]]))
+  expect_true(
+    target_list[[1]]$fit_simple$settings$name %in%
+      targets::tar_deps_raw(target_list[[2]]$object_simple$command$expr)
+  )
+})
+
+targets::tar_test("tar_nlmixr_multimodel fits a piped entry sharing a cmt(0) model end-to-end (#37)", {
+  targets::tar_script({
+    mod <- function() {
+      ini({
+        lcl <- log(0.008); label("Typical value of clearance")
+        lvc <-  log(0.6); label("Typical value of volume of distribution")
+        etalcl + etalvc ~ c(1,
+                            0.01, 1)
+        cpaddSd <- 0.1; label("residual variability")
+      })
+      model({
+        cl <- exp(lcl + etalcl)
+        vc <- exp(lvc + etalvc)
+        kel <- cl/vc
+        d/dt(central) <- -kel*central
+        central(0) <- 0
+        cp <- central/vc
+        cp ~ add(cpaddSd)
+      })
+    }
+
+    nlmixr2targets::tar_nlmixr_multimodel(
+      name = fit_pipe, data = nlmixr2data::pheno_sd, est = "saem",
+      control = nlmixr2est::saemControl(nBurn = 1, nEm = 1),
+      "myfit" = mod,
+      "myfit pipe" = mod |> rxode2::ini(lcl = log(0.01))
+    )
+  })
+  expect_no_error(targets::tar_outdated(callr_function = NULL))
+  suppressWarnings(targets::tar_make(callr_function = NULL))
+  fits <- targets::tar_read(fit_pipe)
+  expect_named(fits, c("myfit", "myfit pipe"))
+  expect_s3_class(fits[["myfit"]], "nlmixr2FitCore")
+  expect_s3_class(fits[["myfit pipe"]], "nlmixr2FitCore")
+})
+
 test_that("tar_nlmixr_multimodel works for within-list model piping (#19), direct testing", {
   pheno <- function() {
     ini({


### PR DESCRIPTION
When a model function declaring compartment initial conditions with `cmt(0) <- value` is both fit directly and piped through `ini()`/`model()` in the same `tar_nlmixr_multimodel()` call (e.g. `"myfit" = mod` alongside `"myfit pipe" = mod |> ini(a <- 2)`), fitting failed with an rxode2 syntax error on `cmt(initial)`.

Root cause: the shared model function is mutated in place from `cmt(0)` to `cmt(initial)` the first time a list entry is processed (so targets' static analysis accepts it). A later entry referencing the same function then performed zero rewrites, so its captured pipe expression was left unwrapped and evaluated the still-`cmt(initial)` body, which nlmixr2 rejects.

Fix: add a `referenced_initial` signal that detects when a pipe references a source function whose body already carries `cmt(initial)`, and wrap such expressions for runtime restoration even when this call rewrote nothing. Detection is scoped to `model({...})` blocks via the new `nlmixr_object_body_has_model_initial()` helper. Pass 1 of the protector was extracted to `tar_nlmixr_protect_zero_initial_env()` to keep cyclomatic complexity under the linter limit.

The gate is deliberately narrow: a self-reference pipe such as `fit_pipe[["myfit"]] |> ini(...)` resolves to a `_fit_simple` target result (a compiled fit, not a source function), so it is left unwrapped. Wrapping it would bury the target dependency inside quote() and hide it from tar_deps_raw(), breaking the issue #19 build ordering.

Adds construction, end-to-end, and boundary regression tests plus unit tests for the new detector.